### PR TITLE
Fix for: Cannot read property 'number' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   View,
   Image,


### PR DESCRIPTION
PropTypes is no longer part of react and is removed in react 16.0.0-beta.5 (the version react-native 0.49.3 uses)