### PR TITLE
fix display when zero value

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ export default class StarReview extends Component {
   }
 
   render() {
-    const view = this.displayValue == null ?
+    const view = (this.displayValue === null || this.displayValue ===undefined) ?
       (this.props.half ? this.halfRatingMode() : this.fullRatingMode())
       :
       this.displayMode()


### PR DESCRIPTION
Referencing to issue #29 

What has changed?

On line 185, now it is compared using strict equality with null or undefined.